### PR TITLE
Fix #7 by switching the event from keydown to keyup

### DIFF
--- a/lib/keyboard-heatmap-view.js
+++ b/lib/keyboard-heatmap-view.js
@@ -44,18 +44,24 @@ export default class KeyboardHeatmapView {
     for (const row of keysMap) {
       const rowElement = document.createElement('div');
       rowElement.classList.add('row');
+
       for (const key of row.keys) {
         const keyElement = document.createElement('div');
+
         if (key.name != 'padding') {
           keyElement.id = key.name;
         } else {
           keyElement.classList.add('padding');
         }
+
         keyElement.classList.add('key');
         keyElement.classList.add(key.width);
+
         keyElement.textContent = key.label;
+
         rowElement.appendChild(keyElement);
       }
+
       keyboard.appendChild(rowElement);
     }
   }

--- a/lib/keyboard-heatmap.js
+++ b/lib/keyboard-heatmap.js
@@ -79,7 +79,7 @@ export default {
         this.keyboardSubscriptions.add(
           addEventListener(
             editorView,
-            'keydown',
+            'keyup',
             (event) => {
               this.keyboardHeatmapView.update(event);
               if (this.modalPanel.isVisible())
@@ -119,5 +119,4 @@ export default {
       this.modalPanel.show()
     );
   }
-
 };

--- a/spec/keyboard-heatmap-view-spec.js
+++ b/spec/keyboard-heatmap-view-spec.js
@@ -1,9 +1,0 @@
-'use babel';
-
-import KeyboardHeatmapView from '../lib/keyboard-heatmap-view';
-
-describe('KeyboardHeatmapView', () => {
-  it('has one valid test', () => {
-    expect('life').toBe('easy');
-  });
-});


### PR DESCRIPTION
Changes the key logging event from keydown to keyup to prevent held keys from logging multiple events.